### PR TITLE
[Feat] #5 테마 조회 기능 구현

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -33,7 +33,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
 		<dependency>

--- a/project/src/main/java/com/Group4/MiniProject/controller/ThemeController.java
+++ b/project/src/main/java/com/Group4/MiniProject/controller/ThemeController.java
@@ -1,0 +1,27 @@
+package com.Group4.MiniProject.controller;
+
+import com.Group4.MiniProject.dto.ThemeResponseDto;
+import com.Group4.MiniProject.entity.Theme;
+import com.Group4.MiniProject.service.ThemeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/themes")
+@RequiredArgsConstructor
+public class ThemeController {
+
+    private final ThemeService themeService;
+
+    @GetMapping
+    public ResponseEntity<List<ThemeResponseDto>> getAllThemes() {
+        List<ThemeResponseDto> themes = themeService.getAllThemes();
+
+        return ResponseEntity.ok(themes);
+    }
+}

--- a/project/src/main/java/com/Group4/MiniProject/dto/ThemeResponseDto.java
+++ b/project/src/main/java/com/Group4/MiniProject/dto/ThemeResponseDto.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 @Getter
 public class ThemeResponseDto {
     private Long themeId;
+    private String name;
     private String imgUrl;
 
     public ThemeResponseDto(Theme theme) {
         this.themeId = theme.getThemeId();
+        this.name = theme.getName();
         this.imgUrl = theme.getImgUrl();
     }
 }

--- a/project/src/main/java/com/Group4/MiniProject/dto/ThemeResponseDto.java
+++ b/project/src/main/java/com/Group4/MiniProject/dto/ThemeResponseDto.java
@@ -1,0 +1,15 @@
+package com.Group4.MiniProject.dto;
+
+import com.Group4.MiniProject.entity.Theme;
+import lombok.Getter;
+
+@Getter
+public class ThemeResponseDto {
+    private Long themeId;
+    private String imgUrl;
+
+    public ThemeResponseDto(Theme theme) {
+        this.themeId = theme.getThemeId();
+        this.imgUrl = theme.getImgUrl();
+    }
+}

--- a/project/src/main/java/com/Group4/MiniProject/entity/Theme.java
+++ b/project/src/main/java/com/Group4/MiniProject/entity/Theme.java
@@ -13,9 +13,7 @@ public class Theme {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    // 🛠TODO: change to STRING or ENUM TYPE
     private Long themeId;
-
-    private String field;
-    private String field2;
-    private String field3;
+    private String imgUrl;
 }

--- a/project/src/main/java/com/Group4/MiniProject/entity/Theme.java
+++ b/project/src/main/java/com/Group4/MiniProject/entity/Theme.java
@@ -15,5 +15,6 @@ public class Theme {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     // 🛠TODO: change to STRING or ENUM TYPE
     private Long themeId;
+    private String name;
     private String imgUrl;
 }

--- a/project/src/main/java/com/Group4/MiniProject/service/ThemeService.java
+++ b/project/src/main/java/com/Group4/MiniProject/service/ThemeService.java
@@ -1,0 +1,23 @@
+package com.Group4.MiniProject.service;
+
+import com.Group4.MiniProject.entity.Theme;
+import com.Group4.MiniProject.dto.ThemeResponseDto;
+import com.Group4.MiniProject.repository.ThemeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ThemeService {
+
+    private final ThemeRepository themeRepository;
+
+    public List<ThemeResponseDto> getAllThemes() {
+        List<Theme> themes = themeRepository.findAll();
+
+        return themes.stream().map(ThemeResponseDto::new).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
테마를 조회하는 기능을 구현했습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- 기존의 theme 테이블의 불필요한 칼럼을 제거하고 아이디, 테마 이름, 이미지 url로 정리했습니다.
<img width="419" height="117" alt="스크린샷 2025-10-22 오전 11 22 55" src="https://github.com/user-attachments/assets/826c9947-087d-4fe1-8943-09750eda1462" />

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`ThemeResponseDto`
- 조회된 데이터를 모두 dto로 반환해야하므로 dto 생성자의 인자를 theme 엔티티 객체로 받도록 했습니다. 필드를 생성자 내부에서 한번에 처리할 수 있습니다.
```java
public class ThemeResponseDto {
    private Long themeId;
    private String imgUrl;

    public ThemeResponseDto(Theme theme) {
        this.themeId = theme.getThemeId();
        this.imgUrl = theme.getImgUrl();
    }
}
```
`ThemeService`
- 응답객체로 변환 시 `ThemeResponseDto::new`를 이용하여 간단하게 변환하도록 구현했습니다.
```java
return themes.stream().map(ThemeResponseDto::new).collect(Collectors.toList());
```

더미데이터로 넣어둔 값이 응답으로 잘 나타납니다!
<img width="594" height="109" alt="스크린샷 2025-10-22 오전 11 41 34" src="https://github.com/user-attachments/assets/01fefebd-e933-4f68-810d-9c0b70631324" />
<img width="708" height="201" alt="스크린샷 2025-10-22 오전 11 44 25" src="https://github.com/user-attachments/assets/d80c96d5-d9c5-424b-96fa-fa3af2bee33d" />


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- closed: #5 
