### PR TITLE
[Feat] #9 메세지 조회 구현

### DIFF
--- a/project/src/main/java/com/Group4/MiniProject/Message/controller/MessageController.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/controller/MessageController.java
@@ -29,7 +29,7 @@ public class MessageController {
 
     @GetMapping
     public ResponseEntity<List<MessageListResponseDto>> getMessageList(
-            @RequestParam(name = "userId") Long userId // 닉네임을 쿼리 파라미터로 받습니다.
+            @RequestParam(name = "userId") Long userId // userId 쿼리 파라미터로 받습니다.
     ) {
         // Service 메서드 호출
         List<MessageListResponseDto> messages =
@@ -37,6 +37,15 @@ public class MessageController {
 
         return ResponseEntity.ok(messages);
     }
+
+    @GetMapping("/unopened")
+    public ResponseEntity<Long> getUnopenedMessageCount(
+            @RequestParam(name = "userId") Long userId // userId 쿼리 파라미터로 받습니다.
+    ) {
+        Long count = messageService.getUnopenedMessageCount(userId);
+        return ResponseEntity.ok(count);
+    }
+
 
     // 메시지 개별 조회
     @GetMapping("/{messageId}")

--- a/project/src/main/java/com/Group4/MiniProject/Message/controller/MessageController.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/controller/MessageController.java
@@ -1,13 +1,15 @@
 package com.Group4.MiniProject.Message.controller;
 
-import com.Group4.MiniProject.Message.dto.MessageRequestDto;
-import com.Group4.MiniProject.Message.dto.MessageResponseDto;
+import com.Group4.MiniProject.Message.dto.MessageCreateRequestDto;
+import com.Group4.MiniProject.Message.dto.MessageCreateResponseDto;
+import com.Group4.MiniProject.Message.dto.MessageListResponseDto;
 import com.Group4.MiniProject.Message.service.MessageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -19,16 +21,27 @@ public class MessageController {
 
     // 메시지 작성 API
     @PostMapping
-    public ResponseEntity<String> createMessage(@Valid @RequestBody MessageRequestDto requestDto) {
+    public ResponseEntity<String> createMessage(@Valid @RequestBody MessageCreateRequestDto requestDto) {
         String senderNickname = requestDto.getSenderNickname();
         messageService.createMessage(requestDto, senderNickname);
         return ResponseEntity.ok("ok");
     }
 
+    @GetMapping
+    public ResponseEntity<List<MessageListResponseDto>> getMessageList(
+            @RequestParam(name = "userId") Long userId // 닉네임을 쿼리 파라미터로 받습니다.
+    ) {
+        // Service 메서드 호출
+        List<MessageListResponseDto> messages =
+                messageService.getMessageListByUserIdAndOpenStatus(userId);
+
+        return ResponseEntity.ok(messages);
+    }
+
     // 메시지 개별 조회
     @GetMapping("/{messageId}")
-    public ResponseEntity<MessageResponseDto> getMessageDetail(@PathVariable UUID messageId) {
-        MessageResponseDto message = messageService.getMessageDetail(messageId);
+    public ResponseEntity<MessageCreateResponseDto> getMessageDetail(@PathVariable UUID messageId) {
+        MessageCreateResponseDto message = messageService.getMessageDetail(messageId);
         return ResponseEntity.ok(message);
     }  
 }

--- a/project/src/main/java/com/Group4/MiniProject/Message/dto/MessageCreateRequestDto.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/dto/MessageCreateRequestDto.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class MessageRequestDto {
+public class MessageCreateRequestDto {
 
     private Long themeId;
 

--- a/project/src/main/java/com/Group4/MiniProject/Message/dto/MessageCreateResponseDto.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/dto/MessageCreateResponseDto.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class MessageResponseDto {
+public class MessageCreateResponseDto {
     private Long longId;
     private UUID uuid;
     private String message;
@@ -24,7 +24,7 @@ public class MessageResponseDto {
     @JsonIgnoreProperties({"receivedMessages", "ingredient"})
     private User receivedUser;
 
-    public MessageResponseDto(Message message) {
+    public MessageCreateResponseDto(Message message) {
         this.longId = message.getId();
         this.uuid = message.getUuid();
         this.receivedUser = message.getReceivedUser();

--- a/project/src/main/java/com/Group4/MiniProject/Message/dto/MessageListResponseDto.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/dto/MessageListResponseDto.java
@@ -1,0 +1,20 @@
+package com.Group4.MiniProject.Message.dto;
+
+import com.Group4.MiniProject.Message.entity.Message;
+import com.Group4.MiniProject.Theme.entity.Theme;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class MessageListResponseDto {
+    private UUID uuid;
+    private Long themeId;
+    private String nickname;
+
+    public MessageListResponseDto(Message message) {
+        this.uuid = message.getUuid();
+        this.themeId = message.getTheme().getThemeId();
+        this.nickname = message.getNickname();
+    }
+}

--- a/project/src/main/java/com/Group4/MiniProject/Message/repository/MessageRepository.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/repository/MessageRepository.java
@@ -17,6 +17,9 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     // userId와 isOpen=true 기준으로 리스트 조회
     List<Message> findByReceivedUserIdAndIsOpenTrue(Long userId);
 
+    // userId를 기준으로 isOpen=false인 메세지 개수 조회
+    long countByReceivedUserIdAndIsOpenFalse(Long userId);
+
     // 메시지 개별 조회
     Optional<Message> findByUuid(UUID uuid);
 

--- a/project/src/main/java/com/Group4/MiniProject/Message/repository/MessageRepository.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/repository/MessageRepository.java
@@ -14,6 +14,9 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     // 메시지 조회
     List<Message> findByReceivedUserId(Long userId);
 
+    // userId와 isOpen=true 기준으로 리스트 조회
+    List<Message> findByReceivedUserIdAndIsOpenTrue(Long userId);
+
     // 메시지 개별 조회
     Optional<Message> findByUuid(UUID uuid);
 

--- a/project/src/main/java/com/Group4/MiniProject/Message/service/MessageService.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/service/MessageService.java
@@ -108,4 +108,8 @@ public class MessageService {
                 .map(MessageListResponseDto::new)
                 .collect(Collectors.toList());
     }
+
+    public Long getUnopenedMessageCount(Long userId) {
+        return messageRepository.countByReceivedUserIdAndIsOpenFalse(userId);
+    }
 }

--- a/project/src/main/java/com/Group4/MiniProject/Message/service/MessageService.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/service/MessageService.java
@@ -1,8 +1,9 @@
 package com.Group4.MiniProject.Message.service;
 
-import com.Group4.MiniProject.Message.dto.MessageRequestDto;
-import com.Group4.MiniProject.Message.dto.MessageResponseDto;
+import com.Group4.MiniProject.Message.dto.MessageCreateRequestDto;
+import com.Group4.MiniProject.Message.dto.MessageCreateResponseDto;
 import com.Group4.MiniProject.Ingredient.entity.Ingredient;
+import com.Group4.MiniProject.Message.dto.MessageListResponseDto;
 import com.Group4.MiniProject.Message.entity.Message;
 import com.Group4.MiniProject.Theme.entity.Theme;
 import com.Group4.MiniProject.User.entity.User;
@@ -20,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,14 +33,14 @@ public class MessageService {
     private final IngredientRepository ingredientRepository;
 
     // 메시지 개별 조회
-    public MessageResponseDto getMessageDetail(UUID messageId) {
+    public MessageCreateResponseDto getMessageDetail(UUID messageId) {
         Message message = messageRepository.findByUuid(messageId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "해당 메시지를 찾을 수 없습니다."
                 ));
 
         // DTO로 변환하여 반환
-        return new MessageResponseDto(message);
+        return new MessageCreateResponseDto(message);
 
         // 빌더 패턴이 null 값으로 보내주게 되어 주석 차리
 //        return MessageResponseDto.builder()
@@ -56,7 +58,7 @@ public class MessageService {
     * @param senderNickname 메시지를 보내는 사람(로그인한 유저)의 닉네임
     */
     @Transactional
-    public void createMessage(MessageRequestDto requestDto, String senderNickname) {
+    public void createMessage(MessageCreateRequestDto requestDto, String senderNickname) {
 
         // 수신자 조회
         User receiver = userRepository.findByNickname(requestDto.getReceivedNickname())
@@ -96,5 +98,14 @@ public class MessageService {
         }
 
         ingredientRepository.save(ingredient);
+    }
+
+    public List<MessageListResponseDto> getMessageListByUserIdAndOpenStatus(Long userId) {
+        // userId와 isOpen=true를 조건으로 사용
+        List<Message> messages = messageRepository.findByReceivedUserIdAndIsOpenTrue(userId);
+        // 엔티티 리스트를 DTO 리스트로 변환하여 반환
+        return messages.stream()
+                .map(MessageListResponseDto::new)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
메세지 조회와 관련된 기능을 구현합니다.
## 🎫 Changes

- 메세지 도메인 내에 api가 여러개 있어 dto 파일 이름을 조금 더 명확하게 수정했습니다.

<!-- 작업 내용을 리스트로 작성해주세요. -->
<img width="783" height="147" alt="스크린샷 2025-10-23 오후 5 16 23" src="https://github.com/user-attachments/assets/e9b7c392-1029-42c8-9951-e3faa3bc2c46" />

- 열어 본 메세지 리스트 조회
<img width="1392" height="912" alt="스크린샷 2025-10-23 오후 5 17 00" src="https://github.com/user-attachments/assets/64d7e282-391b-4838-84ba-61a135d4e8ea" />

- 열지 않은 메세지 개수 조회
<img width="1392" height="912" alt="스크린샷 2025-10-23 오후 5 17 17" src="https://github.com/user-attachments/assets/bdf1bd7c-2c7b-414f-8f73-d9196702ce39" />

<img width="1392" height="912" alt="스크린샷 2025-10-23 오후 5 17 07" src="https://github.com/user-attachments/assets/3a89db74-b7e5-4996-963c-604d593fe7ae" />

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 요청이 잘못 되었을 시에 예외처리는 따로 하지 않았는데, 추가하면 좋을 예외 추천해주시면 감사하겠습니다!
- 현재 열지 않은 메세지 개수 조회가 `/api/messages/unopened`이고, 메세지 개별 조회가 `/api/messages/{messageId}`여서 api에 혼동이 올 수도 있는 문제를 발견했습니다.🫠 (개수 조회 url에서 오타가 났을 경우 개별 조회로 보낸 요청으로 인식)
수정을 해야할 것 같은데, 어떻게 수정하면 좋을지 의견 부탁드립니다! 아니면 그냥 둘까요..?

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`열어본 메세지 리스트 조회`
- userId가 일치하고, isOpen상태가 true인 데이터만 반환합니다.
```java
@GetMapping
    public ResponseEntity<List<MessageListResponseDto>> getMessageList(
            @RequestParam(name = "userId") Long userId // userId 쿼리 파라미터로 받습니다.
    ) {
        // Service 메서드 호출
        List<MessageListResponseDto> messages =
                messageService.getMessageListByUserIdAndOpenStatus(userId);

        return ResponseEntity.ok(messages);
    }
```
```java
    public List<MessageListResponseDto> getMessageListByUserIdAndOpenStatus(Long userId) {
        // userId와 isOpen=true를 조건으로 사용
        List<Message> messages = messageRepository.findByReceivedUserIdAndIsOpenTrue(userId);
        // 엔티티 리스트를 DTO 리스트로 변환하여 반환
        return messages.stream()
                .map(MessageListResponseDto::new)
                .collect(Collectors.toList());
    }
```

`열지 않은 메세지 개수 조회`
- userId가 일치하고, isOpen상태가 false인 데이터만 반환합니다.
```java
    @GetMapping("/unopened")
    public ResponseEntity<Long> getUnopenedMessageCount(
            @RequestParam(name = "userId") Long userId // userId 쿼리 파라미터로 받습니다.
    ) {
        Long count = messageService.getUnopenedMessageCount(userId);
        return ResponseEntity.ok(count);
    }
```
```java
    public Long getUnopenedMessageCount(Long userId) {
        return messageRepository.countByReceivedUserIdAndIsOpenFalse(userId);
    }
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- closed: #9 
