### PR TITLE
[feat] #21 열어본 메세지 리스트 조회 시 에러 응답 추가

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.5.0</version>
+			<version>2.7.0</version>
 		</dependency>
 	</dependencies>
 

--- a/project/src/main/java/com/Group4/MiniProject/Message/service/MessageService.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/service/MessageService.java
@@ -103,6 +103,9 @@ public class MessageService {
     public List<MessageListResponseDto> getMessageListByUserIdAndOpenStatus(Long userId) {
         // userId와 isOpen=true를 조건으로 사용
         List<Message> messages = messageRepository.findByReceivedUserIdAndIsOpenTrue(userId);
+        if (messages.isEmpty()) {
+            throw new IllegalArgumentException("열린 메시지가 존재하지 않습니다.");
+        }
         // 엔티티 리스트를 DTO 리스트로 변환하여 반환
         return messages.stream()
                 .map(MessageListResponseDto::new)

--- a/project/src/main/java/com/Group4/MiniProject/common/exception/GlobalExceptionHandler.java
+++ b/project/src/main/java/com/Group4/MiniProject/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.Group4.MiniProject.common.exception;
+
+import com.Group4.MiniProject.common.dto.ErrorResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponseDto> handleIllegalArgumentException(IllegalArgumentException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+
+        ErrorResponseDto errorResponse = new ErrorResponseDto(ex.getMessage());
+
+        // 400 상태 코드와 ErrorResponseDto를 반환
+        return new ResponseEntity<>(errorResponse, status);
+    }
+}


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
열어본 메세지 리스트 조회 시 빈 리스트가 반환되는 이슈 해결

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- 특정 아이디에서만 조회가 되는 것인줄 알았으나, 조건에 맞는 값이 없어 빈 리스트가 반환된 것임을 확인했습니다.
리스트가 비어있을 때 따로 에러 응답을 처리하지 않았는데, 예외처리가 되지 않은 부분을 조회가 되지 않는다고 착각한 것..

- 리스트가 비어있는 경우에 에러코드 400 + 에러dto(에러 메세지)를 response로 보내도록 수정했습니다.
<img width="1072" height="1161" alt="스크린샷 2025-10-27 오전 11 17 43" src="https://github.com/user-attachments/assets/bd88cf00-595a-4c89-9a74-cd1417cb7347" />

- `GlobalExceptionHandler`을 추가하면서 버전 문제가 발생하여 springdoc을 2.7.0버전으로 변경하였습니다.

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`GlobalExceptionHandler`
- 전역 에러 핸들링 클래스를 추가했습니다.
```java
package com.Group4.MiniProject.common.exception;

import com.Group4.MiniProject.common.dto.ErrorResponseDto;
import org.springframework.http.HttpStatus;
import org.springframework.http.ResponseEntity;
import org.springframework.web.bind.annotation.ExceptionHandler;
import org.springframework.web.bind.annotation.RestControllerAdvice;

@RestControllerAdvice
public class GlobalExceptionHandler {

    @ExceptionHandler(IllegalArgumentException.class)
    public ResponseEntity<ErrorResponseDto> handleIllegalArgumentException(IllegalArgumentException ex) {
        HttpStatus status = HttpStatus.BAD_REQUEST;

        ErrorResponseDto errorResponse = new ErrorResponseDto(ex.getMessage());

        // 400 상태 코드와 ErrorResponseDto를 반환
        return new ResponseEntity<>(errorResponse, status);
    }
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- closed: #21
