### PR TITLE
[Feat] 열지않은 편지 목록 조회 로직 구현

### DIFF
--- a/project/src/main/java/com/Group4/MiniProject/Message/controller/MessageController.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/controller/MessageController.java
@@ -39,11 +39,11 @@ public class MessageController {
     }
 
     @GetMapping("/unopened")
-    public ResponseEntity<Long> getUnopenedMessageCount(
+    public ResponseEntity<List<MessageListResponseDto>> getUnopenedMessageList(
             @RequestParam(name = "userId") Long userId // userId 쿼리 파라미터로 받습니다.
     ) {
-        Long count = messageService.getUnopenedMessageCount(userId);
-        return ResponseEntity.ok(count);
+        List<MessageListResponseDto> messages = messageService.getUnopenedMessageList(userId);
+        return ResponseEntity.ok(messages);
     }
 
 

--- a/project/src/main/java/com/Group4/MiniProject/Message/repository/MessageRepository.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/repository/MessageRepository.java
@@ -17,8 +17,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     // userId와 isOpen=true 기준으로 리스트 조회
     List<Message> findByReceivedUserIdAndIsOpenTrue(Long userId);
 
-    // userId를 기준으로 isOpen=false인 메세지 개수 조회
-    long countByReceivedUserIdAndIsOpenFalse(Long userId);
+    // userId와 isOpen=false 기준으로 리스트 조회
+    List<Message> findByReceivedUserIdAndIsOpenFalse(Long userId);
 
     // 메시지 개별 조회
     Optional<Message> findByUuid(UUID uuid);

--- a/project/src/main/java/com/Group4/MiniProject/Message/service/MessageService.java
+++ b/project/src/main/java/com/Group4/MiniProject/Message/service/MessageService.java
@@ -96,7 +96,17 @@ public class MessageService {
                     .collect(Collectors.toList());
         }
 
-        public Long getUnopenedMessageCount(Long userId) {
-            return messageRepository.countByReceivedUserIdAndIsOpenFalse(userId);
+        // 열지 않은 편지 리스트 조회
+        public List<MessageListResponseDto> getUnopenedMessageList(Long userId){
+            // Repository 호출
+            List<Message> messages = messageRepository.findByReceivedUserIdAndIsOpenFalse(userId);
+
+            // 예외 처리
+            if(messages.isEmpty()) throw new IllegalArgumentException("받은 편지가 없습니다.");
+
+            // 엔티티 리스트를 DTO 리스트로 변환하여 반환
+            return messages.stream()
+                    .map(MessageListResponseDto::new)
+                    .collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
## 🎫 What is the PR?
- 열지 않은 편지 개수 확인 기능을 지우고 목록 조회로 변경하였습니다. 

## 🎫 Changes
- Repository: findByReceivedUserIdAndIsOpenFalse 메소드 추가
- Service: 열지 않은 편지 목록 조회 로직 추가
- Controller: unopened를 목록 반환으로 변경

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`MessageRepository`
- findByReceivedUserIdAndIsOpenFalse 메소드 추가
```java
List<Message> findByReceivedUserIdAndIsOpenFalse(Long userId);
```
`MessageService`
```java
// 열지 않은 편지 목록 조회
public List<MessageListResponseDto> getUnopenedMessageList(Long userId) {
    List<Message> messages = messageRepository.findByReceivedUserIdAndIsOpenFalse(userId);

    return messages.stream()
            .map(MessageListResponseDto::new)
            .collect(Collectors.toList());
}
```

### 실행결과
- 입력: userId
<img width="468" height="439" alt="스크린샷 2025-12-10 오후 1 21 52" src="https://github.com/user-attachments/assets/1f6b0407-0392-45a7-b2e5-6e033adbfcbb" />





## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- closed: #29 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Unopened messages endpoint now retrieves and returns detailed message information for unopened messages instead of providing only a count.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->